### PR TITLE
Combine container sandboxing topics and add Firecracker

### DIFF
--- a/content/posts/meetup-launched.md
+++ b/content/posts/meetup-launched.md
@@ -25,7 +25,7 @@ language, its idioms and pitfalls, real-world use cases and more. We also want
 to encourage people to bring their own Go projects for a friendly review, if
 they like.
 
-Here are some topics we gathered:
+Here are some topics that we gathered for talks in future meetups:
 
 * Go modules (coming in [1.12](https://tip.golang.org/doc/go1.12))
 * The Go2 proposals
@@ -42,8 +42,7 @@ Here are some topics we gathered:
 * Proxy landscape, traefik, envoy, diy-solutions
 * Profiling with Go
 * Containers without docker with podman
-* What is gvisor?
-* Kata containers
+* gVisor, Kata Containers, Firecracker: Container sandboxing
 
 We plan a next meeting for March 2019, feel free to join our [meetup
 group](https://www.meetup.com/Leipzig-Golang-and-Cloud/) for updates.


### PR DESCRIPTION
Although gVisor and Kata Containers are different, I think they can be combined in one topic. Maybe "process isolation" would technically be most correct, but with "container sandboxing" everyone knows what this is about.

Regarding that topic Firecracker is popular as well (and was briefly mentioned in the meetup).

- https://firecracker-microvm.github.io/
- https://aws.amazon.com/blogs/aws/firecracker-lightweight-virtualization-for-serverless-computing/
- Although Firecracker can be used on its own, Kata Containers can make use of it as well: https://github.com/kata-containers/documentation/wiki/Initial-release-of-Kata-Containers-with-Firecracker-support