### PR TITLE
Use angle bracket delimited shortcodes to fix h2 anchors

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -24,7 +24,7 @@ contribute or participate.
 
 <img class="half" src="logo.svg" alt="Depiction of a Leipzig Cloud Gopher">
 
-{{% h2 %}}How to participate{{% /h2 %}}
+{{< h2 >}}How to participate{{< /h2 >}}
 
 * follow us on [meetup](https://www.meetup.com/Leipzig-Golang) for updates, or via [RSS feed](https://golangleipzig.space/posts/index.xml)
 * help us spread the word - we're on [twitter](https://twitter.com/golang_leipzig)
@@ -39,14 +39,14 @@ ideas and projects (send us a PM on [twitter](https://twitter.com/golang_leipzig
 organizing this (just [drop me an email](mailto:martin.czygan@gmail.com); we
 have a few nice ideas for events already, but help is always appreciated
 
-{{% h2 %}}Want to host a meetup at your company?{{% /h2 %}}
+{{< h2 >}}Want to host a meetup at your company?{{< /h2 >}}
 
 Your company uses Go or wants to look into it? Why not connect with the local
 Go community by hosting a user group event? We do have presentations on
 interesting technical topics and spark lively discussions. If you are
 interested, [let's talk](mailto:martin.czygan@gmail.com).
 
-{{% h2 %}}Meetup log{{% /h2 %}}
+{{< h2 >}}Meetup log{{< /h2 >}}
 
 We try to sum up every meetup in a short blog post:
 [#12](https://golangleipzig.space/posts/meetup-12-wrapup/),

--- a/content/posts/go-cloud-native-split.md
+++ b/content/posts/go-cloud-native-split.md
@@ -7,7 +7,7 @@ tags:
 - meta
 ---
 
-{{% h2 %}}TL;DR{{% /h2 %}}
+{{< h2 >}}TL;DR{{< /h2 >}}
 
 We will reshuffle meetups a bit: The current [Go and Cloud Native
 meetup](https://www.meetup.com/Leipzig-Golang/) will be split up,
@@ -20,7 +20,7 @@ Leipzig](https://www.meetup.com/Linux-Meetup-Leipzig/) yet and you are
 interested in Enterprise Linux and Cloud Native topics, please join. It's
 awesome!
 
-{{% h2 %}}Background{{% /h2 %}}
+{{< h2 >}}Background{{< /h2 >}}
 
 We started the Go meetup in February 2019 jointly with a Cloud Native label,
 since a lot of Cloud Native tools are actually written in Go. Also, if you
@@ -42,7 +42,7 @@ developer meetups in Leipzig, with
 [Google Developer Group](https://www.meetup.com/GDG-Leipzig/) being just a few
 of them.
 
-{{% h2 %}}Timeline{{% /h2 %}}
+{{< h2 >}}Timeline{{< /h2 >}}
 
 It will take a few weeks to rename all our sites and groups, but the process
 should be done be end of October 2019.

--- a/content/posts/meetup-10-wrapup.md
+++ b/content/posts/meetup-10-wrapup.md
@@ -7,7 +7,7 @@ tags:
 - meetup
 ---
 
-{{% h2 %}}The sync package{{% /h2 %}}
+{{< h2 >}}The sync package{{< /h2 >}}
 
 Virtual [Meetup #10](https://www.meetup.com/Leipzig-Golang/events/268785531/)
 took place on Friday, April 17, 2020, 19:00 CEST via [Zoom](https://zoom.us/)
@@ -60,7 +60,7 @@ shot. At the same time, the atomic counter on calls ensure there has only been
 a single function call.
 
 
-{{% h2 %}}Misc{{% /h2 %}}
+{{< h2 >}}Misc{{< /h2 >}}
 
 In one of the upcoming meetups, we will highlight tools from the
 [Hashicorp stack](https://github.com/hashicorp/), as there is certainly in

--- a/content/posts/meetup-11-wrapup.md
+++ b/content/posts/meetup-11-wrapup.md
@@ -7,7 +7,7 @@ tags:
 - meetup
 ---
 
-{{% h2 %}}Kubeflow{{% /h2 %}}
+{{< h2 >}}Kubeflow{{< /h2 >}}
 
 The data science process is not free of friction, especially when acquiring,
 preparing and cleaning data. But even when data is readily available, one might

--- a/content/posts/meetup-3-wrapup.md
+++ b/content/posts/meetup-3-wrapup.md
@@ -17,7 +17,7 @@ in March 2019](https://blog.golang.org/go-developer-network).
 > mission to empower developer communities with the knowledge, experience, and
 > wisdom to build the next generation of software in Go.
 
-{{% h2 %}}Meetup topics{{% /h2 %}}
+{{< h2 >}}Meetup topics{{< /h2 >}}
 
 We took a closer look at [Go
 modules](https://github.com/golang/go/wiki/Modules) for dependency management
@@ -47,7 +47,7 @@ then it can choose to modify the request (it's [a
 pointer](https://golang.org/pkg/net/http/#HandlerFunc.ServeHTTP), in contrast
 to the response writer).
 
-{{% h2 %}}From Go to Cloud to Linux{{% /h2 %}}
+{{< h2 >}}From Go to Cloud to Linux{{< /h2 >}}
 
 Clouds and Cloud-Native technologies would be nothing without Linux. The [Linux
 Meetup Leipzig](https://www.meetup.com/Linux-Meetup-Leipzig/) hosts interesting
@@ -57,12 +57,12 @@ honeypots](https://www.meetup.com/Linux-Meetup-Leipzig/events/260563903/).
 Since there is overlap in topics, we might organize a joint event in the
 future.
 
-{{% h2 %}}Postponed topics{{% /h2 %}}
+{{< h2 >}}Postponed topics{{< /h2 >}}
 
 * worker pool implementation benchmarks (from [#2](https://golangleipzig.space/posts/second-meetup-wrapup/))
 * [Ramen Linux](https://ramenlinux.com) lightning talk
 
-{{% h2 %}}References{{% /h2 %}}
+{{< h2 >}}References{{< /h2 >}}
 
 * [github.com/golang-leipzig/gomodintro](https://github.com/golang-leipzig/gomodintro)
 * [github.com/spreadshirt/gorilla-handlers-double-gzip-bug](https://github.com/spreadshirt/gorilla-handlers-double-gzip-bug)

--- a/content/posts/meetup-4-wrapup.md
+++ b/content/posts/meetup-4-wrapup.md
@@ -7,7 +7,7 @@ tags:
 - meetup
 ---
 
-{{% h2 %}}Lightning Network Micropayments{{% /h2 %}}
+{{< h2 >}}Lightning Network Micropayments{{< /h2 >}}
 
 Go is popular in the crypocurrency space. The well-rounded standard library and
 great support for networking applications might be one reason. In [Meetup
@@ -36,7 +36,7 @@ away over twenty local and cloud based implementations.
 
 ![](/images/go-bitcoin-books-web.jpg)
 
-{{% h2 %}}The zero value in the wild{{% /h2 %}}
+{{< h2 >}}The zero value in the wild{{< /h2 >}}
 
 Cloud providers SDK API differ in style, this might play a role in the decision
 for a cloud provider as well.
@@ -58,7 +58,7 @@ issue in the [Go Amazon SDK](https://github.com/aws/aws-sdk-go-v2):
 > the string types are represented as string pointers. This make porting
 > existing code difficult. Also, simple initialization become cumbersome ...
 
-{{% h2 %}}Open Source, Companies and Sustainability{{% /h2 %}}
+{{< h2 >}}Open Source, Companies and Sustainability{{< /h2 >}}
 
 Many companies love open source, fewer like to take an active role in
 development and maintenance of free software. However, there are many good
@@ -87,7 +87,7 @@ One initiative for Go is [gof.rs](https://gof.rs/):
 > [github.com/satori/go.uuid](https://github.com/gofrs/uuid), and have started
 > to look at contributing to more projects.
 
-{{% h2 %}}References{{% /h2 %}}
+{{< h2 >}}References{{< /h2 >}}
 
 * [Presentation Slides: Go middleware for monetizing your API on a per-request basis with the Bitcoin Lightning Network](https://golangleipzig.space/downloads/ln-paywall.pdf)
 * Lightning paywall: [ln-paywall](https://github.com/philippgille/ln-paywall)

--- a/content/posts/meetup-5-wrapup.md
+++ b/content/posts/meetup-5-wrapup.md
@@ -7,7 +7,7 @@ tags:
 - meetup
 ---
 
-{{% h2 %}}Bits from the IO package{{% /h2 %}}
+{{< h2 >}}Bits from the IO package{{< /h2 >}}
 
 The [IO package](https://golang.org/pkg/io/) is a central package in the
 standard library, as it provides (among other things) two main interfaces:
@@ -23,7 +23,7 @@ In a lightning talk we dug a bit into the package:
 The IO model is simple and powerful (and reminds one of UNIX pipes).
 
 
-{{% h2 %}}Automate the Web with chromedp{{% /h2 %}}
+{{< h2 >}}Automate the Web with chromedp{{< /h2 >}}
 
 In a code walkthrough we explored [chromedp](https://github.com/chromedp/chromedp), a pure Go library
 talking the Chrome [devtools protocol](https://github.com/ChromeDevTools/devtools-protocol). It allows to run a headless
@@ -40,7 +40,7 @@ programmatically). Running many (even headless) Chrome instances will eat your
 RAM.
 
 
-{{% h2 %}}How do developers discover Go?{{% /h2 %}}
+{{< h2 >}}How do developers discover Go?{{< /h2 >}}
 
 Have you ever wondered about how programmers move from language to language?
 The author of this entertaining and enlightning blog post (and [other
@@ -50,7 +50,7 @@ things](https://github.com/sshuttle/sshuttle)) did as well:
 
 
 
-{{% h2 %}}More Linux and Cloud{{% /h2 %}}
+{{< h2 >}}More Linux and Cloud{{< /h2 >}}
 
 We have a presentation about libpod (a tool to work with OCI images) in the
 pipeline. Meanwhile, do not miss the next [Linux
@@ -60,7 +60,7 @@ Tue, 2019-06-18 about runc and CRI-O.
 
 
 
-{{% h2 %}}References{{% /h2 %}}
+{{< h2 >}}References{{< /h2 >}}
 
 * [IO lightning talk repo](https://github.com/miku/io15min/)
 * [chromedp](https://github.com/chromedp/chromedp)

--- a/content/posts/meetup-6-wrapup.md
+++ b/content/posts/meetup-6-wrapup.md
@@ -7,7 +7,7 @@ tags:
 - meetup
 ---
 
-{{% h2 %}}Where to Go?{{% /h2 %}}
+{{< h2 >}}Where to Go?{{< /h2 >}}
 
 The [Berlin Go User Group
 celebrates](https://www.meetup.com/golang-users-berlin/) its eighth birthday next
@@ -21,7 +21,7 @@ for you - if you are interested, [just drop me a line](mailto:martin.czygan@gmai
 We'll take a short summer break, and will continue in September 2019. Until
 then, enjoy a few references.
 
-{{% h2 %}}References{{% /h2 %}}
+{{< h2 >}}References{{< /h2 >}}
 
 If you haven't played the nerdiest game in town yet, maybe now is the time:
 

--- a/content/posts/meetup-7-wrapup.md
+++ b/content/posts/meetup-7-wrapup.md
@@ -7,7 +7,7 @@ tags:
 - meetup
 ---
 
-{{% h2 %}}Concurrency in Go{{% /h2 %}}
+{{< h2 >}}Concurrency in Go{{< /h2 >}}
 
 ![](/images/cignotes-chapter-1-topics.png)
 

--- a/content/posts/meetup-8-wrapup.md
+++ b/content/posts/meetup-8-wrapup.md
@@ -7,7 +7,7 @@ tags:
 - meetup
 ---
 
-{{% h2 %}}Anatomy of a Go module proxy{{% /h2 %}}
+{{< h2 >}}Anatomy of a Go module proxy{{< /h2 >}}
 
 The Go packaging story started many years ago with `GO15VENDOREXPERIMENT` and
 a myriad of tools for managing dependencies. And, annoyingly `GOPATH` was one
@@ -43,7 +43,7 @@ implementation!
 * This issue started the conversation: [golang/go/issues/34953](https://github.com/golang/go/issues/34953)
 * And a few weeks later, we have: [golang.org/x/mod/zip](https://godoc.org/golang.org/x/mod/zip)
 
-{{% h2 %}}Pull Request Deployment{{% /h2 %}}
+{{< h2 >}}Pull Request Deployment{{< /h2 >}}
 
 Everyone needs this. When a change to a codebase is made, how great would it be
 to just see that single change, e.g. for a given pull request? That's what this
@@ -61,7 +61,7 @@ Motivation:
 
 Read the slides, get inspired, join us next time - and: automate all the things!
 
-{{% h2 %}}Misc{{% /h2 %}}
+{{< h2 >}}Misc{{< /h2 >}}
 
 * Go turned 10 this month - [Happy Birthday](https://blog.golang.org/10years) and thanks for bringing fun back into programming!
 * A new site emerged: [pkg.go.dev/](https://pkg.go.dev/)

--- a/content/posts/meetup-9-wrapup.md
+++ b/content/posts/meetup-9-wrapup.md
@@ -7,7 +7,7 @@ tags:
 - meetup
 ---
 
-{{% h2 %}}Go 1.14{{% /h2 %}}
+{{< h2 >}}Go 1.14{{< /h2 >}}
 
 [Meetup #9](https://www.meetup.com/Leipzig-Golang/events/268785494/)
 took place on Friday, February 21, 2020, 19:00 CEST at
@@ -36,7 +36,7 @@ Recommended podcast: [gotime/112](https://changelog.com/gotime/112).
 
 ----
 
-{{% h2 %}}HTTP Getaway{{% /h2 %}}
+{{< h2 >}}HTTP Getaway{{< /h2 >}}
 
 The [net/http](https://golang.org/pkg/net/http/) package offers many extension points, using interfaces or callbacks - as well as alternative implementations. A few examples are sketched out in [HTTP Getaway](https://github.com/miku/httpgetaway).
 
@@ -49,7 +49,7 @@ always be enough, sometimes only a connection reset will help.
 
 ----
 
-{{% h2 %}}Misc{{% /h2 %}}
+{{< h2 >}}Misc{{< /h2 >}}
 
 * We discussed various ways to handle errors, there has been some updates
   starting with Go 1.13: [Working with Errors in Go
@@ -87,7 +87,7 @@ And much more.
 
 ----
 
-{{% h2 %}}Contributing{{% /h2 %}}
+{{< h2 >}}Contributing{{< /h2 >}}
 
 We want to make it simpler to contribute and to stay up to date with our meetup
 and we may create a mailing list in the future.

--- a/content/posts/second-meetup-wrapup.md
+++ b/content/posts/second-meetup-wrapup.md
@@ -58,7 +58,7 @@ Go or Cloud-Native technologies, we love to hear real-world insights, just ping 
 
 Thanks for dropping by!
 
-{{% h2 %}}References{{% /h2 %}}
+{{< h2 >}}References{{< /h2 >}}
 
 ### Code generation
 


### PR DESCRIPTION
Since [hugo 0.55][1] percent sign delimited shortcodes were interpreted as
markdown which caused our `<h2>` headings to be dropped silently.

To get the old behavior you can either prepend your shortcode template
with

```
{{ $_hugo_config := `{ "version": 1 }` }}
```

or use the `{{< my-shortcode > }}` format.  The latter one is explicit
and thus clearer. ([Details][2])

It boggles my mind that they introduced a breaking
change like this and then also allowed to override the behavior of one
format, now it is unclear how a short code is handled until you know
its template definition.

[1]: https://github.com/gohugoio/hugo/issues/5763
[2]: https://gohugo.io/content-management/shortcodes/#shortcodes-with-markdown