### PR TITLE
Add broken links workflow

### DIFF
--- a/.github/workflows/broken-links.yaml
+++ b/.github/workflows/broken-links.yaml
@@ -1,0 +1,19 @@
+name: broken links
+
+on:
+  push:
+    branches:
+      - source
+
+jobs:
+  broken-links:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: false
+      - name: Check for broken links
+        uses: lycheeverse/lychee-action@master
+        with:
+          args: content/

--- a/.github/workflows/broken-links.yaml
+++ b/.github/workflows/broken-links.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - source
+      # # TODO(2022-12-23): Just added for testing, remove before merge.
+      - check-for-broken-links
 
 jobs:
   broken-links:

--- a/.github/workflows/broken-links.yaml
+++ b/.github/workflows/broken-links.yaml
@@ -19,3 +19,10 @@ jobs:
         uses: lycheeverse/lychee-action@master
         with:
           args: content/
+      - name: Create Issue From File
+        if: github.repository_owner == 'golang-leipzig'
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Broken Links Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue


### PR DESCRIPTION
This uses lychee to check for broken links in the markdown content.  The workflow job is allowed to fail, however we should check and fix the failing links.  If there are failing links an issue is created by the workflow, e.g. https://github.com/golang-leipzig/golang-leipzig.github.io/issues/11.

**TODO**

- [  ] Remove feature branch from workflow condition